### PR TITLE
[Improvement] Use Coroutines Test instead of runBlocking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs = ['-Xjvm-default=compatibility']
+        freeCompilerArgs = ['-Xjvm-default=compatibility', '-Xopt-in=kotlin.RequiresOptIn']
     }
     buildFeatures {
         viewBinding true
@@ -92,6 +92,7 @@ dependencies {
     testImplementation 'io.kotest:kotest-assertions-core-jvm:5.5.4'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'org.robolectric:robolectric:4.9'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
 
     androidTestImplementation 'androidx.test:core-ktx:1.5.0'
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.0"

--- a/app/src/test/java/com/sefford/artdrian/datasources/WallpaperMemoryDataSourceTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/datasources/WallpaperMemoryDataSourceTest.kt
@@ -2,14 +2,15 @@ package com.sefford.artdrian.datasources
 
 import com.karumi.kotlinsnapshot.matchWithSnapshot
 import com.sefford.artdrian.MetadataMother
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WallpaperMemoryDataSourceTest {
 
     private lateinit var dataSource: WallpaperMemoryDataSource
-    private lateinit var api: FakeWallpaperApi
 
     @BeforeEach
     fun setUp() {
@@ -17,33 +18,25 @@ class WallpaperMemoryDataSourceTest {
     }
 
     @Test
-    fun `saves and retrieves metadata`() {
-        runBlocking {
-            dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
-            dataSource.getAllMetadata().matchWithSnapshot()
-        }
+    fun `saves and retrieves metadata`() = runTest {
+        dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
+        dataSource.getAllMetadata().matchWithSnapshot()
     }
 
     @Test
-    fun `an empty dataSource returns a NotFound error`() {
-        runBlocking {
-            dataSource.getAllMetadata().matchWithSnapshot()
-        }
+    fun `an empty dataSource returns a NotFound error`() = runTest {
+        dataSource.getAllMetadata().matchWithSnapshot()
     }
 
     @Test
-    fun `querying an existing metadata ID returns it`() {
-        runBlocking {
-            dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
-            dataSource.getWallpaperMetadata(MetadataMother.FIRST_METADATA_ID).matchWithSnapshot()
-        }
+    fun `querying an existing metadata ID returns it`() = runTest {
+        dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
+        dataSource.getWallpaperMetadata(MetadataMother.FIRST_METADATA_ID).matchWithSnapshot()
     }
 
     @Test
-    fun `querying an not existing metadata ID returns a NotFound error`() {
-        runBlocking {
-            dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
-            dataSource.getWallpaperMetadata(Int.MAX_VALUE.toString()).matchWithSnapshot()
-        }
+    fun `querying an not existing metadata ID returns a NotFound error`() = runTest {
+        dataSource.saveMetadata(MetadataMother.EXAMPLE_METADATA)
+        dataSource.getWallpaperMetadata(Int.MAX_VALUE.toString()).matchWithSnapshot()
     }
 }

--- a/app/src/test/java/com/sefford/artdrian/usecases/DownloadWallpaperTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/usecases/DownloadWallpaperTest.kt
@@ -2,29 +2,27 @@ package com.sefford.artdrian.usecases
 
 import com.karumi.kotlinsnapshot.matchWithSnapshot
 import com.sefford.artdrian.common.FakeFileManager
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DownloadWallpaperTest {
 
     private lateinit var useCase: DownloadWallpaper
 
     @Test
-    fun `returns an URI when the file is successfully saved`() {
-        useCase = DownloadWallpaper(FakeFileManager{ ANY_SAVED_WALLPAPER_URI })
+    fun `returns an URI when the file is successfully saved`() = runTest {
+        useCase = DownloadWallpaper(FakeFileManager { ANY_SAVED_WALLPAPER_URI })
 
-        runBlocking {
-            useCase.download(ANY_WALLPAPER_URL).matchWithSnapshot()
-        }
+        useCase.download(ANY_WALLPAPER_URL).matchWithSnapshot()
     }
 
     @Test
-    fun `returns an PersistenceError with the underlying exception`() {
-        useCase = DownloadWallpaper(FakeFileManager{ throw IllegalStateException("This was an error") })
+    fun `returns an PersistenceError with the underlying exception`() = runTest {
+        useCase = DownloadWallpaper(FakeFileManager { throw IllegalStateException("This was an error") })
 
-        runBlocking {
-            useCase.download(ANY_WALLPAPER_URL).matchWithSnapshot()
-        }
+        useCase.download(ANY_WALLPAPER_URL).matchWithSnapshot()
     }
 
     private companion object {

--- a/app/src/test/java/com/sefford/artdrian/usecases/GetWallpaperTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/usecases/GetWallpaperTest.kt
@@ -5,33 +5,31 @@ import com.sefford.artdrian.MetadataMother
 import com.sefford.artdrian.datasources.FakeWallpaperApi
 import com.sefford.artdrian.datasources.WallpaperMemoryDataSource
 import com.sefford.artdrian.datasources.WallpaperRepository
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
-
+@OptIn(ExperimentalCoroutinesApi::class)
 class GetWallpaperTest {
 
     private lateinit var useCase: GetWallpaper
     private lateinit var local: WallpaperMemoryDataSource
+
     @BeforeEach
     fun setUp() {
         local = WallpaperMemoryDataSource()
-        useCase = GetWallpaper(WallpaperRepository(FakeWallpaperApi{ listOf(MetadataMother.FIRST_METADATA)}, local))
+        useCase = GetWallpaper(WallpaperRepository(FakeWallpaperApi { listOf(MetadataMother.FIRST_METADATA) }, local))
     }
 
     @Test
-    fun `retrieves a wallpaper from the UI`() {
-        runBlocking {
-            useCase.getWallpaper(MetadataMother.FIRST_METADATA_ID).matchWithSnapshot()
-        }
+    fun `retrieves a wallpaper from the UI`() = runTest {
+        useCase.getWallpaper(MetadataMother.FIRST_METADATA_ID).matchWithSnapshot()
     }
 
     @Test
-    fun `returns a not found error if the ID does not exist`() {
-        runBlocking {
-            useCase.getWallpaper(MetadataMother.SECOND_METADATA_ID).matchWithSnapshot()
-        }
+    fun `returns a not found error if the ID does not exist`() = runTest {
+        useCase.getWallpaper(MetadataMother.SECOND_METADATA_ID).matchWithSnapshot()
     }
 }

--- a/app/src/test/java/com/sefford/artdrian/usecases/GetWallpapersTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/usecases/GetWallpapersTest.kt
@@ -6,7 +6,8 @@ import com.sefford.artdrian.datasources.WallpaperApi
 import com.sefford.artdrian.datasources.WallpaperMemoryDataSource
 import com.sefford.artdrian.datasources.WallpaperRepository
 import com.sefford.utils.Files
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.BeforeEach
@@ -14,7 +15,8 @@ import org.junit.jupiter.api.Test
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-internal class GetWallpapersTest: Files {
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetWallpapersTest : Files {
 
     private lateinit var useCase: GetWallpapers
     private lateinit var server: MockWebServer
@@ -34,11 +36,11 @@ internal class GetWallpapersTest: Files {
             .create(WallpaperApi::class.java)
 
     @Test
-    fun `returns the wallpapers`() {
-        server.enqueue(MockResponse().setResponseCode(200).setBody(this::class.java.readResourceFromFile("metadata_response.json")))
+    fun `returns the wallpapers`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(this@GetWallpapersTest::class.java.readResourceFromFile("metadata_response.json"))
+        )
 
-        runBlocking {
-            useCase.getWallpapers().matchWithSnapshot()
-        }
+        useCase.getWallpapers().matchWithSnapshot()
     }
 }

--- a/app/src/test/java/com/sefford/artdrian/usecases/SetWallpaperTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/usecases/SetWallpaperTest.kt
@@ -1,35 +1,28 @@
 package com.sefford.artdrian.usecases
 
 import com.karumi.kotlinsnapshot.matchWithSnapshot
-import com.sefford.artdrian.common.FakeFileManager
 import com.sefford.artdrian.common.FakeWallpaperAdapter
-import com.sefford.artdrian.common.WallpaperAdapter
-import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.BeforeEach
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
-import org.junit.jupiter.api.Assertions.*
-
+@OptIn(ExperimentalCoroutinesApi::class)
 class SetWallpaperTest {
 
     private lateinit var useCase: SetWallpaper
 
     @Test
-    fun `returns successfully after applying the wallpaper`() {
+    fun `returns successfully after applying the wallpaper`() = runTest {
         useCase = SetWallpaper(FakeWallpaperAdapter())
 
-        runBlocking {
-            useCase.setWallpaper(ANY_WALLPAPER_URL).matchWithSnapshot()
-        }
+        useCase.setWallpaper(ANY_WALLPAPER_URL).matchWithSnapshot()
     }
 
     @Test
-    fun `returns the underlying exception`() {
-        useCase = SetWallpaper(FakeWallpaperAdapter{ throw IllegalStateException("This was an error") })
+    fun `returns the underlying exception`() = runTest {
+        useCase = SetWallpaper(FakeWallpaperAdapter { throw IllegalStateException("This was an error") })
 
-        runBlocking {
-            useCase.setWallpaper(ANY_WALLPAPER_URL).matchWithSnapshot()
-        }
+        useCase.setWallpaper(ANY_WALLPAPER_URL).matchWithSnapshot()
     }
 
     private companion object {

--- a/app/src/test/java/com/sefford/artdrian/wallpaperdetail/ui/WallpaperDetailViewModelTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/wallpaperdetail/ui/WallpaperDetailViewModelTest.kt
@@ -5,25 +5,23 @@ import com.sefford.artdrian.di.CoreModule
 import com.sefford.artdrian.di.DaggerTestComponent
 import com.sefford.artdrian.di.DoublesModule
 import com.sefford.artdrian.wallpaperdetail.di.WallpaperDetailModule
-import com.sefford.artdrian.wallpaperlist.ui.WallpaperListViewModel
 import com.sefford.utils.Files
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Before
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-
 import org.junit.jupiter.api.Assertions.*
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
-class WallpaperDetailViewModelTest: Files {
+class WallpaperDetailViewModelTest : Files {
 
     lateinit var viewModel: WallpaperDetailViewModel
     lateinit var server: MockWebServer
@@ -46,49 +44,41 @@ class WallpaperDetailViewModelTest: Files {
     }
 
     @org.junit.Test
-    fun `returns a Content View after a successful retrieval from the repository`() {
+    fun `returns a Content View after a successful retrieval from the repository`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpaper().last().matchWithSnapshot()
-        }
+        viewModel.getWallpaper().last().matchWithSnapshot()
     }
 
     @org.junit.Test
-    fun `notifies an error occurred during the retrieval`() {
+    fun `notifies an error occurred during the retrieval`() = runTest {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
-        runBlocking {
-            viewModel.getWallpaper().last().matchWithSnapshot()
-        }
+        viewModel.getWallpaper().last().matchWithSnapshot()
     }
 
     @org.junit.Test
-    fun `sets the loading spinner when attempting to load`() {
+    fun `sets the loading spinner when attempting to load`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpaper().first().matchWithSnapshot()
-        }
+        viewModel.getWallpaper().first().matchWithSnapshot()
     }
 
     @org.junit.Test
-    fun `re-requesting the view model info skips the loading`() {
+    fun `re-requesting the view model info skips the loading`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpaper().last()
-            viewModel.getWallpaper().toList().matchWithSnapshot()
-        }
+        viewModel.getWallpaper().last()
+        viewModel.getWallpaper().toList().matchWithSnapshot()
     }
 
     private companion object {

--- a/app/src/test/java/com/sefford/artdrian/wallpaperlist/ui/WallpaperListViewModelTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/wallpaperlist/ui/WallpaperListViewModelTest.kt
@@ -5,10 +5,11 @@ import com.sefford.artdrian.di.CoreModule
 import com.sefford.artdrian.di.DaggerTestComponent
 import com.sefford.artdrian.di.DoublesModule
 import com.sefford.utils.Files
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class WallpaperListViewModelTest : Files {
 
@@ -41,48 +43,40 @@ class WallpaperListViewModelTest : Files {
     }
 
     @Test
-    fun `returns a Content View after a successful retrieval from the repository`() {
+    fun `returns a Content View after a successful retrieval from the repository`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpapers().last().matchWithSnapshot()
-        }
+        viewModel.getWallpapers().last().matchWithSnapshot()
     }
 
     @Test
-    fun `notifies an error occurred during the retrieval`() {
+    fun `notifies an error occurred during the retrieval`() = runTest {
         server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
 
-        runBlocking {
-            viewModel.getWallpapers().last().matchWithSnapshot()
-        }
+        viewModel.getWallpapers().last().matchWithSnapshot()
     }
 
     @Test
-    fun `sets the loading spinner when attempting to load`() {
+    fun `sets the loading spinner when attempting to load`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpapers().first().matchWithSnapshot()
-        }
+        viewModel.getWallpapers().first().matchWithSnapshot()
     }
 
     @Test
-    fun `re-requesting the view model info skips the loading`() {
+    fun `re-requesting the view model info skips the loading`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)
                 .setBody("com/sefford/artdrian/usecases/metadata_response.json".readResourceFromFile())
         )
 
-        runBlocking {
-            viewModel.getWallpapers().last()
-            viewModel.getWallpapers().toList().matchWithSnapshot()
-        }
+        viewModel.getWallpapers().last()
+        viewModel.getWallpapers().toList().matchWithSnapshot()
     }
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #13 

### :tophat: What is the goal?

Use Coroutines Test instead of runBlocking

### How is it being implemented?

I found that I was doing the tests incorrectly or at least not optimized by using `runBlocking` blocks instead of the correct `runTest` ones, so I am improving the unit testing by doing it the right way :tm: .

### How can it be tested?

- [ ] **Use case 1:** _Unit testing should keep passing_
