### PR TITLE
#19 Fixes Ghost Waves 003

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3:1.1.0-alpha01'
-    implementation 'androidx.compose.material:material-icons-extended:1.3.0'
+    implementation 'androidx.compose.material:material-icons-extended:1.3.1'
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
@@ -93,6 +93,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'org.robolectric:robolectric:4.9'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
+    testImplementation "net.jqwik:jqwik:1.7.1"
 
     androidTestImplementation 'androidx.test:core-ktx:1.5.0'
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.0"

--- a/app/src/main/java/com/sefford/artdrian/model/Metadata.kt
+++ b/app/src/main/java/com/sefford/artdrian/model/Metadata.kt
@@ -11,3 +11,6 @@ data class Metadata(
   @SerializedName("CreatedAt") val created: Date,
   @SerializedName("UpdatedAt") val updated: Date
 )
+
+fun Metadata.isPngFile(): Boolean = this.slug != "ghost_waves_003"
+

--- a/app/src/main/java/com/sefford/artdrian/model/Wallpaper.kt
+++ b/app/src/main/java/com/sefford/artdrian/model/Wallpaper.kt
@@ -1,12 +1,13 @@
 package com.sefford.artdrian.model
 
+import com.sefford.artdrian.model.Wallpaper.Extension.*
 import java.util.*
 
 data class Wallpaper(val metadata: Metadata) {
     val desktop: String
-        get() = BASE_URL.format(Type.DESKTOP.identifier, metadata.slug)
+        get() = BASE_URL.format(Type.DESKTOP.identifier, metadata.slug, (if (metadata.isPngFile()) PNG else JPG).extension)
     val mobile: String
-        get() = BASE_URL.format(Type.MOBILE.identifier, metadata.slug)
+        get() = BASE_URL.format(Type.MOBILE.identifier, metadata.slug,  (if (metadata.isPngFile()) PNG else JPG).extension)
     val name: String
         get() = metadata.slug.split("_")
             .joinToString(separator = " ") { word ->
@@ -14,11 +15,16 @@ data class Wallpaper(val metadata: Metadata) {
             }
 
     private companion object {
-        val BASE_URL = "https://adrianmato.art/static/downloads/%s/%s.png"
+        val BASE_URL = "https://adrianmato.art/static/downloads/%s/%s.%s"
     }
 
     private enum class Type(val identifier: String) {
         DESKTOP("desktop"),
         MOBILE("mobile")
+    }
+
+    private enum class Extension(val extension: String) {
+        PNG("png"),
+        JPG("jpg")
     }
 }

--- a/app/src/test/java/com/sefford/artdrian/MetadataMother.kt
+++ b/app/src/test/java/com/sefford/artdrian/MetadataMother.kt
@@ -26,6 +26,14 @@ object MetadataMother {
         created = Date.from(LocalDate.parse("2022-11-05").atStartOfDay().toInstant(ZoneOffset.UTC)),
         updated = Date.from(LocalDate.parse("2022-11-05").atStartOfDay().toInstant(ZoneOffset.UTC)),
     )
+    val GHOST_WAVES_003 = Metadata(
+        id = SECOND_METADATA_ID,
+        slug = "ghost_waves_003",
+        views = 100,
+        downloads = 200,
+        created = Date.from(LocalDate.parse("2022-11-05").atStartOfDay().toInstant(ZoneOffset.UTC)),
+        updated = Date.from(LocalDate.parse("2022-11-05").atStartOfDay().toInstant(ZoneOffset.UTC)),
+    )
     val EXAMPLE_METADATA = listOf(
         FIRST_METADATA
     )

--- a/app/src/test/java/com/sefford/artdrian/model/WallpaperTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/model/WallpaperTest.kt
@@ -1,0 +1,25 @@
+package com.sefford.artdrian.model
+
+import com.karumi.kotlinsnapshot.matchWithSnapshot
+import com.sefford.artdrian.MetadataMother
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import net.jqwik.api.*
+import org.junit.jupiter.api.Test
+
+
+class WallpaperTest {
+
+    @Test
+    fun `Ghost Waves 003 indicates it is a JPG wallpaper`() {
+        Wallpaper(MetadataMother.GHOST_WAVES_003).metadata.isPngFile().shouldBeFalse()
+    }
+
+    @Property
+    fun `any other wallpaper indicates it is a PNG wallpaper`(@ForAll("slugs") slug: String) {
+        Wallpaper(MetadataMother.FIRST_METADATA.copy(slug = slug)).metadata.isPngFile().shouldBeTrue()
+    }
+
+    @Provide
+    fun slugs(): Arbitrary<String> = Arbitraries.strings().filter { slug -> slug != MetadataMother.GHOST_WAVES_003.slug }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #19 

### :tophat: What is the goal?

Fix the reason why Ghost Waves 003 was not showing

### How is it being implemented?

Seems like unlike the other URLs, Ghost Waves 003 uses a JPG instead of a PNG, so I needed to introduce a special case into it, and now it shows.

Used some Property-based testing with JQwik to assert the special case.

### Captures, GIF or Videos (UI Tasks)

### How can it be tested?

- [ ] **Use case 1:** _Ghost Waves 003 should be showing now_