### PR TITLE
[ART-50] Register connectivity changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     >
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>

--- a/app/src/main/java/com/sefford/artdrian/Artpplication.kt
+++ b/app/src/main/java/com/sefford/artdrian/Artpplication.kt
@@ -6,6 +6,7 @@ import coil3.PlatformContext
 import coil3.SingletonImageLoader
 import coil3.request.crossfade
 import coil3.util.DebugLogger
+import com.sefford.artdrian.connectivity.ConnectivityStore
 import com.sefford.artdrian.di.ApplicationModule
 import com.sefford.artdrian.di.CoreModule
 import com.sefford.artdrian.di.DaggerApplicationComponent
@@ -17,7 +18,10 @@ import javax.inject.Inject
 class Artpplication : Application(), TopComponentHolder, SingletonImageLoader.Factory {
 
     @Inject
-    internal lateinit var store: WallpaperStore
+    internal lateinit var wallpapers: WallpaperStore
+
+    @Inject
+    internal lateinit var connectivity: ConnectivityStore
 
     override val graph = DaggerApplicationComponent.builder()
         .applicationModule(ApplicationModule(this))
@@ -27,7 +31,7 @@ class Artpplication : Application(), TopComponentHolder, SingletonImageLoader.Fa
     override fun onCreate() {
         super.onCreate()
         graph.inject(this)
-        store.event(WallpaperEvents.Load)
+        wallpapers.event(WallpaperEvents.Load)
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader =

--- a/app/src/main/java/com/sefford/artdrian/connectivity/Connectivity.kt
+++ b/app/src/main/java/com/sefford/artdrian/connectivity/Connectivity.kt
@@ -1,0 +1,71 @@
+package com.sefford.artdrian.connectivity
+
+import android.net.NetworkCapabilities
+import kotlin.math.roundToInt
+
+sealed class Connectivity(
+    val type: Type,
+    val speed: Speed
+) {
+
+    data object Undetermined : Connectivity(Type.DISCONNECTED, Speed.Disconnected)
+
+    data object Disconnected : Connectivity(Type.DISCONNECTED, Speed.Disconnected)
+
+    class Connected(type: Type, speed: Speed) : Connectivity(type, speed) {
+
+        val metered: Boolean by lazy { type == Type.MOBILE }
+
+    }
+
+    enum class Type {
+        DISCONNECTED, MOBILE, WIFI, ETHERNET, OTHER;
+
+        companion object {
+            operator fun invoke(capabilities: NetworkCapabilities): Type = when {
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> WIFI
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> MOBILE
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> ETHERNET
+                else -> OTHER
+            }
+        }
+    }
+
+    sealed class Speed(val speed: Int) {
+
+        data object Disconnected : Speed(0) {
+            override val parallelDownloads: Int = 0
+        }
+
+        class Slow(speed: Int) : Speed(speed) {
+            override val parallelDownloads: Int = 1
+        }
+
+        class Medium(speed: Int) : Speed(speed) {
+            override val parallelDownloads: Int = (speed / 7).coerceAtMost(2)
+        }
+
+        class Fast(speed: Int) : Speed(speed) {
+            override val parallelDownloads: Int = (speed / 7).coerceAtMost(4)
+        }
+
+        abstract val parallelDownloads: Int
+
+        companion object {
+            operator fun invoke(kbps: Int): Speed {
+                val speedMbps = (kbps / 1000.0).roundToInt()
+
+                return when {
+                    speedMbps >= 56 -> ::Fast
+                    speedMbps >= 18.64 -> ::Medium
+                    else -> ::Slow
+                }(speedMbps)
+            }
+        }
+    }
+
+    companion object {
+        operator fun invoke(capabilities: NetworkCapabilities): Connectivity =
+            Connected(type = Type(capabilities), speed = Speed(capabilities.linkDownstreamBandwidthKbps))
+    }
+}

--- a/app/src/main/java/com/sefford/artdrian/connectivity/ConnectivityStore.kt
+++ b/app/src/main/java/com/sefford/artdrian/connectivity/ConnectivityStore.kt
@@ -1,0 +1,22 @@
+package com.sefford.artdrian.connectivity
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import com.sefford.artdrian.stores.HoldsState
+import com.sefford.artdrian.stores.StoreStateStorage
+
+class ConnectivityStore(
+    private val storage: StoreStateStorage<Connectivity>
+) : ConnectivityManager.NetworkCallback(), HoldsState<Connectivity> by storage {
+
+    constructor(initial: Connectivity): this(StoreStateStorage(initial))
+
+    override fun onUnavailable() {
+        storage.state { Connectivity.Disconnected }
+    }
+
+    override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+        storage.state { Connectivity(capabilities) }
+    }
+}

--- a/app/src/main/java/com/sefford/artdrian/connectivity/ConnectivitySubscription.kt
+++ b/app/src/main/java/com/sefford/artdrian/connectivity/ConnectivitySubscription.kt
@@ -1,0 +1,7 @@
+package com.sefford.artdrian.connectivity
+
+interface ConnectivitySubscription {
+    fun start(store: ConnectivityStore)
+
+    fun end()
+}

--- a/app/src/main/java/com/sefford/artdrian/connectivity/DefaultConnectivitySubscription.kt
+++ b/app/src/main/java/com/sefford/artdrian/connectivity/DefaultConnectivitySubscription.kt
@@ -1,0 +1,22 @@
+package com.sefford.artdrian.connectivity
+
+import android.net.ConnectivityManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+class DefaultConnectivitySubscription(
+    private val manager: ConnectivityManager
+) : ConnectivitySubscription {
+
+    private var store: ConnectivityStore? = null
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun start(store: ConnectivityStore) {
+        this.store = store
+        manager.registerDefaultNetworkCallback(store)
+    }
+
+    override fun end() {
+        store?.let { manager.unregisterNetworkCallback(it) }
+    }
+}

--- a/app/src/main/java/com/sefford/artdrian/di/AndroidModule.kt
+++ b/app/src/main/java/com/sefford/artdrian/di/AndroidModule.kt
@@ -2,10 +2,14 @@ package com.sefford.artdrian.di
 
 import android.app.WallpaperManager
 import android.content.Context
+import android.net.ConnectivityManager
 import com.sefford.artdrian.common.FileManager
 import com.sefford.artdrian.common.FileManagerImpl
 import com.sefford.artdrian.common.WallpaperAdapter
 import com.sefford.artdrian.common.WallpaperAdapterImpl
+import com.sefford.artdrian.connectivity.Connectivity
+import com.sefford.artdrian.connectivity.ConnectivitySubscription
+import com.sefford.artdrian.connectivity.DefaultConnectivitySubscription
 import com.sefford.artdrian.utils.DefaultLogger
 import com.sefford.artdrian.utils.Logger
 import dagger.Module
@@ -37,4 +41,18 @@ class AndroidModule {
     @Provides
     @Singleton
     fun provideLogger(logger: DefaultLogger): Logger = logger
+
+    @Provides
+    @Singleton
+    fun provideConnectivityManager(@Application context: Context): ConnectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    @Provides
+    @Singleton
+    fun provideConnectivitySubscription(manager: ConnectivityManager): ConnectivitySubscription =
+        DefaultConnectivitySubscription(manager)
+
+    @Provides
+    fun provideDefaultConnectivity(manager: ConnectivityManager): Connectivity =
+        manager.getNetworkCapabilities(manager.activeNetwork)?.let { Connectivity(it) } ?: Connectivity.Undetermined
 }

--- a/app/src/main/java/com/sefford/artdrian/di/CoreModule.kt
+++ b/app/src/main/java/com/sefford/artdrian/di/CoreModule.kt
@@ -1,5 +1,8 @@
 package com.sefford.artdrian.di
 
+import com.sefford.artdrian.connectivity.Connectivity
+import com.sefford.artdrian.connectivity.ConnectivityStore
+import com.sefford.artdrian.connectivity.ConnectivitySubscription
 import com.sefford.artdrian.data.db.WallpaperDao
 import com.sefford.artdrian.data.db.WallpaperDatabase
 import com.sefford.artdrian.data.network.DelegatedHttpClient
@@ -11,8 +14,6 @@ import com.sefford.artdrian.model.MetadataResponse
 import com.sefford.artdrian.model.SingleMetadataResponse
 import com.sefford.artdrian.utils.DefaultLogger
 import com.sefford.artdrian.utils.Logger
-import com.sefford.artdrian.utils.forceCache
-import com.sefford.artdrian.utils.isFromCache
 import com.sefford.artdrian.wallpapers.effects.WallpaperDomainEffectHandler
 import com.sefford.artdrian.wallpapers.store.WallpaperStateMachine
 import com.sefford.artdrian.wallpapers.store.WallpaperStore
@@ -23,7 +24,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.DefaultRequest
-import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.cache.HttpCache
 import io.ktor.client.plugins.cache.storage.CacheStorage
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -134,4 +134,9 @@ class CoreModule {
             .launchIn(MainScope().plus(Dispatchers.IO))
         return store
     }
+
+    @Provides
+    @Singleton
+    fun provideConnectivityStore(initial: Connectivity, subscription: ConnectivitySubscription): ConnectivityStore =
+        ConnectivityStore(initial).also { subscription.start(it) }
 }

--- a/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityStoreTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityStoreTest.kt
@@ -1,0 +1,4 @@
+package com.sefford.artdrian.connectivity
+
+class ConnectivityStoreTest {
+}

--- a/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityStoreTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityStoreTest.kt
@@ -1,4 +1,49 @@
 package com.sefford.artdrian.connectivity
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import androidx.test.core.app.ApplicationProvider
+import com.sefford.artdrian.stores.StoreStateStorage
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
 class ConnectivityStoreTest {
+
+    private val cm =
+        ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val storage = StoreStateStorage<Connectivity>(Connectivity.Undetermined)
+    private val store = ConnectivityStore(storage = storage)
+
+    @Test
+    fun `reports capabilities change`() {
+        val capabilities = shadowOf(NetworkCapabilities()).apply {
+            addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+        }.setLinkDownstreamBandwidthKbps(HIGH_SPEED)
+
+
+        store.onCapabilitiesChanged(cm.activeNetwork!!, capabilities)
+
+        store.state.value.shouldBeInstanceOf<Connectivity.Connected>().should { connectivity ->
+            connectivity.type shouldBe Connectivity.Type.WIFI
+            connectivity.speed.shouldBeInstanceOf<Connectivity.Speed.Fast>()
+        }
+    }
+
+    @Test
+    fun `reports disconnection`() {
+        store.onUnavailable()
+
+        store.state.value.shouldBeInstanceOf<Connectivity.Disconnected>()
+    }
+
 }
+
+private const val HIGH_SPEED = 100_000
+

--- a/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityTest.kt
@@ -1,4 +1,83 @@
 package com.sefford.artdrian.connectivity
 
+import android.net.NetworkCapabilities
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
 class ConnectivityTest {
+
+    @Test
+    fun `creates a WiFi connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+
+        Connectivity(capabilities).type shouldBe Connectivity.Type.WIFI
+    }
+
+    @Test
+    fun `creates a mobile connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        Connectivity(capabilities).type shouldBe Connectivity.Type.MOBILE
+    }
+
+    @Test
+    fun `creates an ethernet connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
+
+        Connectivity(capabilities).type shouldBe Connectivity.Type.ETHERNET
+    }
+
+    @Test
+    fun `creates other connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+
+        Connectivity(capabilities).type shouldBe Connectivity.Type.OTHER
+    }
+
+    @Test
+    fun `creates low speed connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).setLinkDownstreamBandwidthKbps(LOW_SPEED)
+
+        Connectivity(capabilities).speed.shouldBeInstanceOf<Connectivity.Speed.Slow>()
+    }
+
+    @Test
+    fun `creates medium speed connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).setLinkDownstreamBandwidthKbps(MEDIUM_SPEED)
+
+        Connectivity(capabilities).speed.shouldBeInstanceOf<Connectivity.Speed.Medium>()
+    }
+
+    @Test
+    fun `creates fast speed connectivity`() {
+        val capabilities = shadowOf(NetworkCapabilities()).setLinkDownstreamBandwidthKbps(HIGH_SPEED)
+
+        Connectivity(capabilities).speed.shouldBeInstanceOf<Connectivity.Speed.Fast>()
+    }
+
+    @Test
+    fun `reports metered connection`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+
+        Connectivity(capabilities).shouldBeInstanceOf<Connectivity.Connected>().metered.shouldBeTrue()
+    }
+
+    @Test
+    fun `reports unmetered connection`() {
+        val capabilities = shadowOf(NetworkCapabilities()).addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+
+        Connectivity(capabilities).shouldBeInstanceOf<Connectivity.Connected>().metered.shouldBeFalse()
+    }
 }
+
+private const val LOW_SPEED = 10_000
+private const val MEDIUM_SPEED = 25_000
+private const val HIGH_SPEED = 100_000
+

--- a/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityTest.kt
+++ b/app/src/test/java/com/sefford/artdrian/connectivity/ConnectivityTest.kt
@@ -1,0 +1,4 @@
+package com.sefford.artdrian.connectivity
+
+class ConnectivityTest {
+}


### PR DESCRIPTION
### :pushpin: References
Closes #50

### :tophat: What is the goal?

Monitor connectivity for 

### How is it being implemented?

I used a Network Callback plus the StateStorage to create a Store where I can subscribe for changes on the connectivity.

With this I am able to discern between WiFi/Ethernet/Mobile and analyze connectivity speeds.

I will use this to prepare a pre-fetch of the Wallpapers later on
